### PR TITLE
Add in mass file deletion into ransomware sig

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -65,6 +65,15 @@ class RansomwareFileModifications(Signature):
     def on_complete(self):
         ret = False
 
+        deletedfiles = self.results["behavior"]["summary"]["delete_files"]
+        deletedcount = 0
+        for deletedfile in deletedfiles:
+            if "\\temp\\" not in deletedfile.lower() and not deletedfile.lower().endswith(".tmp"):
+                deletedcount += 1
+        if deletedcount > 100:
+            self.data.append({"mass file_delete" : "Appears to have deleted %s files indicative of ransomware or wiper malware deleting files to prevent recovery" % (deletedcount)})
+            ret = True
+
         if self.movefilecount > 60:
             self.data.append({"file_modifications" : "Performs %s file moves indicative of a potential file encryption process" % (self.movefilecount)})
             ret = True

--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -71,7 +71,7 @@ class RansomwareFileModifications(Signature):
             if "\\temp\\" not in deletedfile.lower() and not deletedfile.lower().endswith(".tmp"):
                 deletedcount += 1
         if deletedcount > 100:
-            self.data.append({"mass file_delete" : "Appears to have deleted %s files indicative of ransomware or wiper malware deleting files to prevent recovery" % (deletedcount)})
+            self.data.append({"mass file_deletion" : "Appears to have deleted %s files indicative of ransomware or wiper malware deleting files to prevent recovery" % (deletedcount)})
             ret = True
 
         if self.movefilecount > 60:


### PR DESCRIPTION
This was a missing behaviour. Seen in various ransomwares and wipers such as Cryptoshield MD5 e4d7596676b884563d9af2eef3642b1f