### PR TITLE
Fix false positive on clear logs signature

### DIFF
--- a/modules/signatures/clears_logs.py
+++ b/modules/signatures/clears_logs.py
@@ -47,7 +47,6 @@ class ClearsLogs(Signature):
             if match_file:
                 for match in match_file:
                     self.data.append({"file" : match})
-                self.found_autorun = True
-            ret = True        
+                ret = True        
 
         return ret


### PR DESCRIPTION
Indentation issue triggering false positives as return True is always triggered