### PR TITLE
Remote sniffer aux feature

### DIFF
--- a/conf/auxiliary.conf
+++ b/conf/auxiliary.conf
@@ -21,16 +21,20 @@ enabled = no
 # Enable or disable the use of an external sniffer (tcpdump) [yes/no].
 enabled = yes
 
+# enable remote tcpdump support
+remote = yes
+host = root@192.168.122.1
+
 # Specify the path to your local installation of tcpdump. Make sure this
 # path is correct.
 tcpdump = /usr/sbin/tcpdump
 
 # Specify the network interface name on which tcpdump should monitor the
 # traffic. Make sure the interface is active.
-interface = eth1
+interface = br0
 
 # Specify a Berkeley packet filter to pass to tcpdump.
-# bpf = not arp
+bpf = not arp
 
 [tor]
 # Enable or disable the use of Tor transparent proxying
@@ -44,7 +48,7 @@ interface = eth1
 # to a daemon running as root, which can run the
 # iptables rules itself. For a working example, see
 # https://github.com/seanthegeek/routetor
-enabled = yes
+enabled = no
 
 # Specify the path to a binary or script that will initiate the firewall
 # rules to redirect traffic to the Tor transparent proxy.  The file
@@ -64,7 +68,7 @@ torstop = /usr/sbin/torstop
 # (new-style) password protection from Office documents before analysis.
 #
 # See https://github.com/herumi/msoffice
-decryptor = /opt/cuckoo/msoffice/bin/msoffice-crypt.exe
+decryptor = /home/cuckoo/bin/msoffice-crypt.exe
 
 [gateways]
 #RTR1 = 192.168.1.254
@@ -87,20 +91,21 @@ dlpath = /tmp/
 # Web UI settings
 
 [display_browser_martians]
-enabled = no
+enabled = yes
 
 [display_office_martians]
-enabled = no
-
+enabled = yes
+ 
 [display_shrike]
-enabled = no
-
+enabled = yes
+ 
 [expanded_dashboard]
 # displays package, custom field, malfamily, clamav, PCAP link, and extended suricata results
-enabled = no
+enabled = yes
 
 [display_et_portal]
-enabled = no
+enabled = yes
 
 [display_pt_portal]
-enabled = no
+enabled = yes
+

--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -118,8 +118,8 @@ class Sniffer(Auxiliary):
 	        log.info("Started remote sniffer @ %s with (interface=%s, host=%s, "
 	      	         "dump path=%s)", remote_host, interface, host, file_path)
 
-		x = os.system("ssh %s 'nohup /tmp/a.sh > /tmp/log 2>/tmp/err &'" % remote_host)
-		#remote_output = subprocess.check_output(['ssh', remote_host, "/bin/bash /tmp/a.sh" ], stderr=subprocess.STDOUT)
+		# x = os.system("ssh %s 'nohup /tmp/a.sh > /tmp/log 2>/tmp/err &'" % remote_host)
+		remote_output = subprocess.check_output(['ssh', remote_host, 'nohup', '/tmp/a.sh', '>','/tmp/log','2>','/tmp/err','&' ], stderr=subprocess.STDOUT)
 	else:
 	        try:
 		    self.proc = subprocess.Popen(pargs, stdout=subprocess.PIPE,

--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -120,7 +120,6 @@ class Sniffer(Auxiliary):
 
 		x = os.system("ssh %s 'nohup /tmp/a.sh > /tmp/log 2>/tmp/err &'" % remote_host)
 		#remote_output = subprocess.check_output(['ssh', remote_host, "/bin/bash /tmp/a.sh" ], stderr=subprocess.STDOUT)
-		#print(remote_output)
 	else:
 	        try:
 		    self.proc = subprocess.Popen(pargs, stdout=subprocess.PIPE,
@@ -141,19 +140,15 @@ class Sniffer(Auxiliary):
 	if remote: 
         	remote_host = self.options.get("host", "")
 		remote_args = [ 'ssh', remote_host, 'killall' , '-9', 'tcpdump' ]
-		print(remote_args)
 		remote_output = subprocess.check_output(remote_args, stderr=subprocess.STDOUT)
-		print(remote_output)
 
         	file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses",
                                  "%s" % self.task.id, "dump.pcap")
 		file_path2 = "/tmp/tcp.dump.%d" % self.task.id
 
 		remote_output = subprocess.check_output([ 'scp', '-q', remote_host + ":" + file_path2, file_path ], stderr=subprocess.STDOUT)
-		print(remote_output)
 
 		remote_output = subprocess.check_output([ 'ssh', remote_host, 'rm', '-f', file_path2 ], stderr=subprocess.STDOUT)
-		print(remote_output)
 		return
 
         if self.proc and not self.proc.poll():

--- a/modules/auxiliary/sniffer.py
+++ b/modules/auxiliary/sniffer.py
@@ -23,7 +23,12 @@ class Sniffer(Auxiliary):
         self.machine = self.db.view_machine_by_label(self.machine.label)
         tcpdump = self.options.get("tcpdump", "/usr/sbin/tcpdump")
         bpf = self.options.get("bpf", "")
-        file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses",
+        remote = self.options.get("remote", "no")
+        remote_host = self.options.get("host", "")
+	if remote:
+		file_path = "/tmp/tcp.dump.%d" % self.task.id
+	else:
+        	file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses",
                                  "%s" % self.task.id, "dump.pcap")
         host = self.machine.ip
         # Selects per-machine interface if available.
@@ -78,10 +83,11 @@ class Sniffer(Auxiliary):
         except:
             pass
         else:
-            pargs.extend(["-Z", user])
+	    if not remote:
+	            pargs.extend(["-Z", user])
 
         pargs.extend(["-w", file_path])
-        pargs.extend(["host", host])
+        pargs.extend(["'", "host", host])
         # Do not capture XMLRPC agent traffic.
         pargs.extend(["and", "not", "(", "dst", "host", host, "and", "dst", "port",
                       str(CUCKOO_GUEST_PORT), ")", "and", "not", "(", "src", "host",
@@ -94,23 +100,62 @@ class Sniffer(Auxiliary):
                       "src", "port", resultserver_port, ")"])
 
         if bpf:
-            pargs.extend(["and", "(", bpf, ")"])
+            pargs.extend(["and", "("] + bpf.split(' ') + [ ")" ] )
 
-        try:
-            self.proc = subprocess.Popen(pargs, stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE)
-        except (OSError, ValueError):
-            log.exception("Failed to start sniffer (interface=%s, host=%s, "
-                          "dump path=%s)", interface, host, file_path)
-            return
+        pargs.extend(["'"])
 
-        log.info("Started sniffer with PID %d (interface=%s, host=%s, "
-                 "dump path=%s)", self.proc.pid, interface, host, file_path)
+	if remote and not remote_host:
+		log.exception("Failed to start sniffer, remote enabled but no ssh string has been specified")
+		return
+	elif remote:
+		f = open("/tmp/" + str(self.task.id) + ".sh", "w")
+		# remote_args = [ 'ssh', remote_host, 'nohup', ' '.join(pargs), '&' ]
+		if f:
+			f.write( ' '.join(['nohup', ' '.join(pargs), '&']))
+			f.write("\n")
+			f.close()
+		remote_output = subprocess.check_output(['scp', '-q', "/tmp/" + str(self.task.id) + ".sh", remote_host + ":/tmp/a.sh"  ], stderr=subprocess.STDOUT)
+	        log.info("Started remote sniffer @ %s with (interface=%s, host=%s, "
+	      	         "dump path=%s)", remote_host, interface, host, file_path)
+
+		x = os.system("ssh %s 'nohup /tmp/a.sh > /tmp/log 2>/tmp/err &'" % remote_host)
+		#remote_output = subprocess.check_output(['ssh', remote_host, "/bin/bash /tmp/a.sh" ], stderr=subprocess.STDOUT)
+		#print(remote_output)
+	else:
+	        try:
+		    self.proc = subprocess.Popen(pargs, stdout=subprocess.PIPE,
+				stderr=subprocess.PIPE)
+	        except (OSError, ValueError):
+	            log.exception("Failed to start sniffer (interface=%s, host=%s, "
+	                          "dump path=%s)", interface, host, file_path)
+	            return
+
+	        log.info("Started sniffer with PID %d (interface=%s, host=%s, "
+	      	         "dump path=%s)", self.proc.pid, interface, host, file_path)
 
     def stop(self):
         """Stop sniffing.
         @return: operation status.
         """
+        remote = self.options.get("remote", "no")
+	if remote: 
+        	remote_host = self.options.get("host", "")
+		remote_args = [ 'ssh', remote_host, 'killall' , '-9', 'tcpdump' ]
+		print(remote_args)
+		remote_output = subprocess.check_output(remote_args, stderr=subprocess.STDOUT)
+		print(remote_output)
+
+        	file_path = os.path.join(CUCKOO_ROOT, "storage", "analyses",
+                                 "%s" % self.task.id, "dump.pcap")
+		file_path2 = "/tmp/tcp.dump.%d" % self.task.id
+
+		remote_output = subprocess.check_output([ 'scp', '-q', remote_host + ":" + file_path2, file_path ], stderr=subprocess.STDOUT)
+		print(remote_output)
+
+		remote_output = subprocess.check_output([ 'ssh', remote_host, 'rm', '-f', file_path2 ], stderr=subprocess.STDOUT)
+		print(remote_output)
+		return
+
         if self.proc and not self.proc.poll():
             try:
                 self.proc.terminate()


### PR DESCRIPTION
This allows for CAPE/Cuckoo to run inside a VM, This allows you to install QEMU/KVM on the hostos, use ssh keys and allow for remote start up.

A follow up request contains the same feature for remote memory dumping and data gathering.

This allows us to spin up and manage CAPE/Cuckoo host better.