### PR TITLE
avoid SSL/TLS problem with recent vSphere 6.7 release

### DIFF
--- a/modules/machinery/vsphere.py
+++ b/modules/machinery/vsphere.py
@@ -85,8 +85,7 @@ class vSphere(Machinery):
         # Workaround for PEP-0476 issues in recent Python versions
         if self.options.vsphere.unverified_ssl:
             import ssl
-            sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-            sslContext.verify_mode = ssl.CERT_NONE
+            sslContext = ssl._create_unverified_context()
             self.connect_opts["sslContext"] = sslContext
             log.warn("Turning off SSL certificate verification!")
 


### PR DESCRIPTION
TLSv1 is unsupported in recent vSphere.
Using '_create_unverified_context' for create correct context.

Same as: https://github.com/cuckoosandbox/cuckoo/pull/2365