### PR TITLE
Feature to suppress all network traffic based upon dns names, specific ip addresses to follow maybe? example file included

### DIFF
--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -62,6 +62,9 @@ enabled = yes
 # the IP from fakedns which would then remove all domains associated with that
 # resolved IP
 dnswhitelist = no
+# additional entries
+dnswhitelist_file = /home/cuckoo/cape/extra/whitelist_domains.txt
+
 
 [static]
 enabled = yes

--- a/extra/whitelist_domains.txt
+++ b/extra/whitelist_domains.txt
@@ -1,0 +1,31 @@
+
+# default domains whitelist
+
+# Microsoft 365 / Live
+login\.live\.com$
+skydrivesync\.policies\.live\.net$
+settings-win\.data\.microsoft\.com$
+sls\.update\.microsoft\.com$
+client-office365-tas\.msedge\.net$
+\.skype\.com$
+api\.onedrive\.com$
+\.live\.com$
+
+# Microsoft
+watson\.telemetry\.microsoft\.com$
+ieonlinews\.microsoft\.com$
+www\.microsoft\.com$
+ocsp\.msocsp\.com$
+adl\.windows\.com$
+fe2\.update\.microsoft\.com$
+fe3\.delivery\.mp\.microsoft\.com$
+download\.windowsupdate\.com$
+\.microsoft\.com
+\.windowsupdate\.com
+\.windows\.com$
+\.edgesuite\.net$
+blob\.core\.windows\.net$
+
+# Google
+update\.googleapis\.com$
+


### PR DESCRIPTION
Got tired of having microsoft hosts in my network results and the original feature did not work.  Additionally, it did not allow to add more hosts to the list, nor did it filter out any of the protocol specific addresses.  This left a lot of additional "junk".

Please let me know if I've missed anthing.