### PR TITLE
Fix typo in reporting.conf for callback module

### DIFF
--- a/conf/reporting.conf
+++ b/conf/reporting.conf
@@ -140,7 +140,7 @@ dropped = no
 registry = no
 mutexes = no
 
-[notification]
+[callback]
 enabled = no
 # will send as post data {"task_id":X}
 # can be coma separated urls 


### PR DESCRIPTION
Fixed `Reporting module callback not found in configuration file`