### PR TITLE
fix IOError: image file is truncated (20 bytes not processed)

### DIFF
--- a/modules/processing/deduplication.py
+++ b/modules/processing/deduplication.py
@@ -3,11 +3,13 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
+import logging
 import imagehash
 from PIL import Image
 import six
 
 from lib.cuckoo.common.abstracts import Processing
+log = logging.getLogger()
 
 class Deduplicate(Processing):
     """Deduplicate screenshots."""
@@ -51,22 +53,25 @@ class Deduplicate(Processing):
         self.key = "deduplicated_shots"
         shots = []
 
-        hashmethod = "whash-db4"
-        if hashmethod == 'ahash':
-            hashfunc = imagehash.average_hash
-        elif hashmethod == 'phash':
-            hashfunc = imagehash.phash
-        elif hashmethod == 'dhash':
-            hashfunc = imagehash.dhash
-        elif hashmethod == 'whash-haar':
-            hashfunc = imagehash.whash
-        elif hashmethod == 'whash-db4':
-            hashfunc = lambda img: imagehash.whash(img, mode='db4')
+        try:
+            hashmethod = "whash-db4"
+            if hashmethod == 'ahash':
+                hashfunc = imagehash.average_hash
+            elif hashmethod == 'phash':
+                hashfunc = imagehash.phash
+            elif hashmethod == 'dhash':
+                hashfunc = imagehash.dhash
+            elif hashmethod == 'whash-haar':
+                hashfunc = imagehash.whash
+            elif hashmethod == 'whash-db4':
+                hashfunc = lambda img: imagehash.whash(img, mode='db4')
 
-        shots_path = os.path.join(self.analysis_path, "shots")
-        if os.path.exists(shots_path):
-            screenshots = self.deduplicate_images(userpath=shots_path, hashfunc=hashfunc)
-            for screenshot in screenshots:
-                shots.append(screenshot.replace(".jpg",""))
+            shots_path = os.path.join(self.analysis_path, "shots")
+            if os.path.exists(shots_path):
+                screenshots = self.deduplicate_images(userpath=shots_path, hashfunc=hashfunc)
+                for screenshot in screenshots:
+                    shots.append(screenshot.replace(".jpg",""))
+        except Exception as e:
+            log.error(e)
 
         return shots


### PR DESCRIPTION
```
2018-10-09 20:04:06,064 [lib.cuckoo.core.plugins] ERROR: Failed to run the processing module "Deduplicate":
Traceback (most recent call last):
  File "$CUCKOO_ROOT/utils/../lib/cuckoo/core/plugins.py", line 197, in process
    data = current.run()
  File "$CUCKOO_ROOT/utils/../modules/processing/deduplication.py", line 68, in run
    screenshots = self.deduplicate_images(userpath=shots_path, hashfunc=hashfunc)
  File "$CUCKOO_ROOT/utils/../modules/processing/deduplication.py", line 40, in deduplicate_images
    hash = hashfunc(Image.open(img))
  File "$CUCKOO_ROOT/utils/../modules/processing/deduplication.py", line 64, in <lambda>
    hashfunc = lambda img: imagehash.whash(img, mode='db4')
  File "/usr/local/lib/python2.7/dist-packages/imagehash/__init__.py", line 260, in whash
    image = image.convert("L").resize((image_scale, image_scale), Image.ANTIALIAS)
  File "/usr/local/lib/python2.7/dist-packages/PIL/Image.py", line 846, in convert
    self.load()
  File "/usr/local/lib/python2.7/dist-packages/PIL/ImageFile.py", line 218, in load
    "(%d bytes not processed)" % len(b))
IOError: image file is truncated (20 bytes not processed)

```