### PR TITLE
Fixed digital signature display on the web UI

### DIFF
--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -766,10 +766,8 @@ class PortableExecutable(object):
                             sha1_fingerprint = cert.get_fingerprint('sha1').lower().rjust(40, '0')
                             md5_fingerprint = cert.get_fingerprint('md5').lower().rjust(32, '0')
                             subject_str = str(cert.get_subject())
-                            try:
-                                cn = subject_str[subject_str.index("/CN=")+len("/CN="):]
-                            except:
-                                continue
+                            cn = subject_str.split("/CN=", 1)[-1]
+                            cn = cn.decode("string_escape", errors="ignore").decode("utf-8", errors="ignore")
                             retlist.append({
                                 "sn": str(sn),
                                 "cn": cn,


### PR DESCRIPTION
The canonical name (CN) field of the digital signature is retrieved using the M2Crypto Python library.
For some reason this library returns the value double escaped (i.e. instead of `\xc2\xa9 Microsoft Corporation` it returns `\\xc2\\xa9 Microsoft Corporation`, where `\xc2\xa9` is the UTF-8 encoding of the copyright character).

This commit is intended to fix that to be able to display the proper name on the web UI.

Before (in report.json):
```
            "digital_signers": [
                {
                    "md5_fingerprint": "da7e8b97a27c307943d4918049c51141",
                    "sha1_fingerprint": "a3a2aa1580fed056bab156e6c1af772ebd3cb3cb",
                    "sn": "1",
                    "cn": "\\xc2\\xa9 Microsoft Corporation. All rights reserved."
                }
            ],
```

Before (on the web UI):
```
Certificate Common Name
\xC2\xA9 Microsoft Corporation. All rights reserved.
```

After (in report.json):
```
            "digital_signers": [
                {
                    "md5_fingerprint": "da7e8b97a27c307943d4918049c51141",
                    "sha1_fingerprint": "a3a2aa1580fed056bab156e6c1af772ebd3cb3cb",
                    "sn": "1",
                    "cn": "\u00a9 Microsoft Corporation. All rights reserved."
                }
            ],
```

After (on the web UI):
Before (on the web UI):
```
Certificate Common Name
© Microsoft Corporation. All rights reserved.
```
