### PR TITLE
Remove bad line for DDE (breaks cuckoo)

### DIFF
--- a/modules/processing/static.py
+++ b/modules/processing/static.py
@@ -1222,7 +1222,6 @@ class Office(object):
         officeresults = results["office"] = {}
 
         # extract DDE
-        results["office_dde"] = 
         dde = extract_dde(filepath)
         if dde:
             results["office_dde"] = convert_to_printable(dde)


### PR DESCRIPTION
This line seems to cause traceback issue preventing cuckoo starting. I removed it and tested against a DDE file and seems to work fine now.