### PR TITLE
Add in string Java string length check

### DIFF
--- a/modules/signatures/static_java.py
+++ b/modules/signatures/static_java.py
@@ -63,7 +63,7 @@ class Static_Java(Signature):
                 self.data.append({"serialized_object" : "Contains use of a Java serialized object" })
                 self.weight += 1
 
-            # Check individual string length for possible ofbuscation
+            # Check individual string length for possible obfuscation
             for string in decompiled.split():
                 if len(string) > 150:
                     self.data.append({"string_length" : "Contains very large strings indicative of obfuscation" })

--- a/modules/signatures/static_java.py
+++ b/modules/signatures/static_java.py
@@ -121,7 +121,7 @@ class Static_Java(Signature):
                 exploit += 1
 
             if exploit > 0:
-                self.description += " and contains possible exploit code."
+                self.description += " and possible exploit code."
                 self.severity = 3
                 self.weight += 1
 

--- a/modules/signatures/static_java.py
+++ b/modules/signatures/static_java.py
@@ -63,6 +63,14 @@ class Static_Java(Signature):
                 self.data.append({"serialized_object" : "Contains use of a Java serialized object" })
                 self.weight += 1
 
+            # Check individual string length for possible ofbuscation
+            for string in decompiled.split():
+                if len(string) > 150:
+                    self.data.append({"string_length" : "Contains very large strings indicative of obfuscation" })
+                    self.severity = 3
+                    self.weight += 1
+                    break
+
             # Specific Exploit Detections
             # http://stopmalvertising.com/malware-reports/watering-hole-attack-cve-2012-4792-and-cve-2012-0507.html
             if "AtomicReferenceArray" in decompiled:


### PR DESCRIPTION
Good check mentioned in original fireeye doc https://www.fireeye.com/content/dam/fireeye-www/global/en/current-threats/pdfs/wp-a-daily-grind-filtering-java-vulnerabilities.pdf.

As a side note if you resubmit a JAR file it looks like procyon/static analysis not done i.e. SHA 256 3a260a6cfb923ebe96c9db26f0840eec6ac9d18d897e96ed1469b66d0c6e2f1a.