### PR TITLE
Add signature to highlight CAPE family detection

### DIFF
--- a/modules/signatures/CAPE.py
+++ b/modules/signatures/CAPE.py
@@ -526,3 +526,21 @@ class CAPE_TransactedHollowing(Signature):
     def on_complete(self):
         if self.transacted_hollowing == True:
             return True
+
+class CAPEDetectedThreat(Signature):
+    name = "CAPE detected a specific threat"
+    description = "CAPE detected a specific malware threat"
+    severity = 3
+    categories = ["malware"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    def run(self):
+
+        if "cape" in self.results:
+            detection = self.results["cape"]
+            self.description = "CAPE detected %s malware" % detection
+            return True
+
+        return False

--- a/modules/signatures/CAPE.py
+++ b/modules/signatures/CAPE.py
@@ -540,7 +540,7 @@ class CAPEDetectedThreat(Signature):
 
         if "cape" in self.results:
             detection = self.results["cape"]
-            self.description = "CAPE detected %s malware" % detection
+            self.description = "CAPE detected the %s malware family" % detection
             return True
 
         return False


### PR DESCRIPTION
Adding in a signature to highlight family detection for CAPE. While this is visually presented already in several places this is merely to tie it to a signature so that it improves the score further.

I have tested and it is working but please have an check over the signature for the logic just in case I am missing something.