### PR TITLE
Rewrite of Powershell command signature

### DIFF
--- a/modules/signatures/powershell_command.py
+++ b/modules/signatures/powershell_command.py
@@ -78,7 +78,7 @@ class PowershellCommandSuspicious(Signature):
 
                 # Decode base64 strings for reporting; will adjust this later to add detection matches against decoded content. We don't take into account here when a variable is used i.e. "$encoded = BASE64_CONTENT -enc $encoded" and so evasion from decoding the content is possible. Alternatively we could just try to hunt for base64 content in powershell command lines but this will need to be tested
                 if "-e " in lower or "/e " in lower or "-en " in lower or "/en " in lower or "-enc" in lower or "/enc" in lower:
-                    b64strings = re.findall(r'[-\/][eE][nNcCoOdDeE]{0,6}\ (\S+)', cmdline)
+                    b64strings = re.findall(r'[-\/][eE][nNcCoOdDeEmMaA]{0,13}\ (\S+)', cmdline)
                     for b64string in b64strings:
                         encoded = str(b64string)
                         decoded = base64.b64decode(encoded)


### PR DESCRIPTION
This signature as it stands in its current form was not working. Took matches from it and now instead of a lit of anomalies just dumps the powershell command (for now) which I think is more useful.

Also implemented a base64 decoding function which while not perfect should be able to extract and present decoded base64 strings although this requires it is following a base64 string so for instance "-enc BASE64" not a variable like "$content = BASE64 -enc $content". A solution to this would be extract and decode all base64 strings but with evasion, dosfuscation etc. this may be difficult. As such between this signature and some of the command line signatures most suspicious powershell commands are detected IF they are using these features or obfuscation.

I will improve this signature over time. I did consider attempting my first ML project with this after being inspired here https://www.fireeye.com/blog/threat-research/2018/07/malicious-powershell-detection-via-machine-learning.html but I think this is not entirely necessary the now as enough detections exist and also I don't have enough malicious and varied examples of malicious powershell commands let alone real world benign examples for training and edge cases.

Another note is that because of obfsucation ordering does not matter and it is common to see a command line now build out powershell commands and arguments into variables before the next command calls an extremely obfuscated command as powershell executes but it is too obfuscated to match on (curtain obviously will resolve this once matching is added to this signature). For now though we don't care about ordering just that the terms exist in the command line so cmd.exe $1 = -enc $2= pOwErShell will still detect it as a powershell command.