### PR TITLE
Add in Base64 sanity check

### DIFF
--- a/modules/signatures/powershell_command.py
+++ b/modules/signatures/powershell_command.py
@@ -16,7 +16,6 @@
 from lib.cuckoo.common.abstracts import Signature
 
 import base64
-import binascii
 
 try:
     import re2 as re

--- a/modules/signatures/powershell_command.py
+++ b/modules/signatures/powershell_command.py
@@ -16,7 +16,6 @@
 from lib.cuckoo.common.abstracts import Signature
 
 import base64
-
 try:
     import re2 as re
 except ImportError:

--- a/modules/signatures/powershell_command.py
+++ b/modules/signatures/powershell_command.py
@@ -16,6 +16,8 @@
 from lib.cuckoo.common.abstracts import Signature
 
 import base64
+import binascii
+
 try:
     import re2 as re
 except ImportError:
@@ -81,13 +83,16 @@ class PowershellCommandSuspicious(Signature):
                     b64strings = re.findall(r'[-\/][eE][nNcCoOdDeEmMaA]{0,13}\ (\S+)', cmdline)
                     for b64string in b64strings:
                         encoded = str(b64string)
-                        decoded = base64.b64decode(encoded)
-                        self.data.append({"decoded_base64_string" : decoded})
+                        if re.match('^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$', encoded):
+                            decoded = base64.b64decode(encoded)
+                            self.data.append({"decoded_base64_string" : decoded})
+
                 if "frombase64string(" in lower:
                     b64strings = re.findall(r'[fF][rR][oO][mM][bB][aA][sS][eE]64[sS][tT][rR][iI][nN][gG]\([\"\'](\S+)[\"\']\)', cmdline)
                     for b64string in b64strings:
                         encoded = str(b64string)
-                        decoded = base64.b64decode(encoded)
-                        self.data.append({"decoded_base64_string" : decoded})
+                        if re.match('^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$', encoded):
+                            decoded = base64.b64decode(encoded)
+                            self.data.append({"decoded_base64_string" : decoded})
 
         return ret


### PR DESCRIPTION
Add in check to make sure string that has been extracted is actually base64 to avoid any type errors if variables and encodings are used like -enc $b64 which the code would could try and decode and possible then break the sig with a type error.