### PR TITLE
Add in heapspray detection signature

### DIFF
--- a/modules/signatures/exploit_heapspray.py
+++ b/modules/signatures/exploit_heapspray.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2018 Cuckoo Technologies raw.githubusercontent.com/cuckoosandbox/community/master/modules/signatures/windows/exploitation.py, Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ExploitHeapspray(Signature):
+    name = "exploit_heapspray"
+    description = "A possible heap spray exploit has been detected"
+    severity = 3
+    confidence = 40
+    categories = ["exploit"]
+    authors = ["Cuckoo Technologies", "Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.mem = {}
+        self.prot = {}
+        self.heaptotals = dict()
+
+        self.procs = [
+        "acrobat.exe",
+        "acrord32.exe",
+        "chrome.exe",
+        "excel.exe",
+        "firefox.exe",
+        "hwp.exe",
+        "iexplore.exe",
+        "outlook.exe",
+        "powerpnt.exe",
+        "winword.exe",
+        ]
+
+    filter_apinames = set(["NtAllocateVirtualMemory"])
+
+    def on_call(self, call, process):
+        pname = process["process_name"].lower()
+        protection = self.get_argument(call, "Protection")
+        region_size = int(self.get_argument(call, "RegionSize"), 0)
+        if pname in self.procs:
+            combo = pname, region_size, protection
+            self.mem[combo] = self.mem.get(combo, 0) + 1
+            self.prot[protection] = protection
+
+    def on_complete(self):
+        for combo, count in self.mem.items():
+            pname, region_size, protection = combo
+            written = int(region_size) * int(count)/1024/1024
+            if count >= 50:
+                if pname not in self.heaptotals:
+                    self.heaptotals[pname] = 0
+                self.heaptotals[pname] += written
+
+        if self.heaptotals:
+            for pname, total in self.heaptotals.items():
+                if total > 200:
+                    self.data.append({"heap spray": "%s allocated %s megabytes to memory" % (pname,total)})
+
+        if self.data:
+            return True
+        else:
+            return False


### PR DESCRIPTION
This technique is still used in some exploits but particularly older exploits if being analyzed. This is converted from the Cuckoo Sandbox sig that was written by Cuckoo Team and myself.