### PR TITLE
Fix FPs in stack pivot sig

### DIFF
--- a/modules/signatures/stack_pivot.py
+++ b/modules/signatures/stack_pivot.py
@@ -27,7 +27,6 @@ class StackPivot(Signature):
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
-        self.ignore_it = True
         self.procs = set()
         self.processes = [
             "acrobat.exe",


### PR DESCRIPTION
Restricting this to certain processes and simplifying it somewhat although it needs simplified more.  The issue is if you execute an office document say and cuckoo is monitoring other processes like explorer.exe that have a "stack pivot" or curtain or something like that a false positive is generated. By restricting it to limited list this is negated. 

As a note the process list will need to be expanded further to cover other applications but critical ones are there.