### PR TITLE
Add in missing errno import in resultserver.py

### DIFF
--- a/lib/cuckoo/core/resultserver.py
+++ b/lib/cuckoo/core/resultserver.py
@@ -6,6 +6,7 @@ import os
 import socket
 import select
 import logging
+import errno
 import datetime
 import SocketServer
 from threading import Event, Thread


### PR DESCRIPTION
2018-12-19 14:18:56,863 [root] INFO: Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
Traceback (most recent call last):
  File "cuckoo.py", line 138, in <module>
    test=args.test)
  File "cuckoo.py", line 71, in cuckoo_init
    ResultServer()
  File "/REMOVED/CAPE/lib/cuckoo/common/utils.py", line 1641, in __call__
    cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
  File "/REMOVED/CAPE/lib/cuckoo/core/resultserver.py", line 59, in __init__
    if e.errno == errno.EADDRINUSE:
NameError: global name 'errno' is not defined