### PR TITLE
Delete libvirt's default REJECT rules

### DIFF
--- a/utils/rooter.py
+++ b/utils/rooter.py
@@ -115,6 +115,12 @@ def flush_rttable(rt_table):
 def forward_enable(src, dst, ipaddr):
     """Enable forwarding a specific IP address from one interface into
     another."""
+    # Delete libvirt's default FORWARD REJECT rules. e.g.:
+    # -A FORWARD -o virbr0 -j REJECT --reject-with icmp-port-unreachable
+    # -A FORWARD -i virbr0 -j REJECT --reject-with icmp-port-unreachable
+    run(settings.iptables, "-D", "FORWARD", "-i", src, "-j", "REJECT")
+    run(settings.iptables, "-D", "FORWARD", "-o", src, "-j", "REJECT")
+
     run(settings.iptables, "-A", "FORWARD", "-i", src, "-o", dst,
         "--source", ipaddr, "-j", "ACCEPT")
 


### PR DESCRIPTION
Delete libvirt's default REJECT rules in the iptables `FORWARD` table when `forward_enable()` is called.