### PR TITLE
Update Kronos.yar

### DIFF
--- a/data/yara/CAPE/Kronos.yar
+++ b/data/yara/CAPE/Kronos.yar
@@ -8,6 +8,7 @@ rule Kronos
         $a1 = "user_pref(\"network.cookie.cookieBehavior\""
         $a2 = "T0E0H4U0X3A3D4D8"
         $a3 = "wow64cpu.dll" wide
+        $a4 = "Kronos" fullword ascii wide
     condition:
         uint16(0) == 0x5A4D and (any of ($a*))
 }


### PR DESCRIPTION
Add default mutex name "Kronos" if mutex generation fails.