### PR TITLE
Set static django-ratelimit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ python-whois
 bs4
 pefile2==1.2.11
 git+https://github.com/crackinglandia/pype32.git
-git+https://github.com/jsocol/django-ratelimit
+django-ratelimit==2.0.0
 git+https://github.com/kbandla/pydeep.git
 pyvmomi>=6.0
 imagehash


### PR DESCRIPTION
the git version is throwing errors

File "/home/cuckoo/CAPE/web/web/wsgi.py", line 89, in <module>
    application = get_wsgi_application()
  File "/home/cuckoo/venv/lib/python2.7/site-packages/django/core/wsgi.py", line 14, in get_wsgi_application
    return WSGIHandler()
  File "/home/cuckoo/venv/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 151, in __init__
    self.load_middleware()
  File "/home/cuckoo/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 58, in load_middleware
    mw_instance = mw_class()
TypeError: __init__() takes exactly 2 arguments (1 given)