### PR TITLE
Update JavaDropper.yar

### DIFF
--- a/data/yara/CAPE/JavaDropper.yar
+++ b/data/yara/CAPE/JavaDropper.yar
@@ -8,10 +8,7 @@ rule JavaDropper
         cape_type = "JavaDropper Payload"
 
     strings:
-	    $jar = "META-INF/MANIFEST.MF"
-
-	    $a1 = "ePK"
-	    $a2 = "kPK"
+	$jar = "META-INF/MANIFEST.MF"
 
         $b1 = "config.ini"
         $b2 = "password.ini"
@@ -21,5 +18,5 @@ rule JavaDropper
         $d1 = "c.dat"
 
     condition:
-        $jar and (all of ($a*) or all of ($b*) or all of ($c*) or all of ($d*))
+        $jar and (all of ($b*) or all of ($c*) or all of ($d*))
 }


### PR DESCRIPTION
Remove the following variables:
```
	    $a1 = "ePK"
	    $a2 = "kPK"
```
This will decrease false positives, specifically those where ransomware will encrypt files, touch JAR files and CAPE will trigger the JavaDropper sig, which is incorrect. This change should result in a very low false negative rate.