### PR TITLE
Add PowerPool signatures

### DIFF
--- a/data/yara/CAPE/PowerPool.yar
+++ b/data/yara/CAPE/PowerPool.yar
@@ -1,0 +1,16 @@
+rule PowerPool {
+    meta:
+        author = "ditekshen"
+        description = "PowerPool Stage 1 Backdoor Payload"
+        cape_type = "PowerPool Payload"
+    strings:
+        $str1 = "cmd /c powershell.exe " wide
+        $str2 = "rar.exe a -r %s.rar" wide
+        $str3 = "MyDemonMutex%d" wide
+        $str4 = "CMD COMMAND EXCUTE ERROR!" ascii
+        $str5 = "/?id=%s&info=%s" wide
+        $str6 = "MyScreen.jpg" wide
+        $str7 = "proxy.log" wide
+    condition:
+        uint16(0) == 0x5A4D and 5 of them
+}

--- a/modules/signatures/powerpool_mutex.py
+++ b/modules/signatures/powerpool_mutex.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2019 ditekshen
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class PowerpoolMutexes(Signature):
+    name = "powerpool_mutexes"
+    description = "Creates known PowerPool mutexes"
+    severity = 3
+    categories = ["trojan"]
+    families = ["PowerPool"]
+    authors = ["ditekshen"]
+    minimum = "0.5"
+
+    def run(self):
+        indicators = [
+            "MyDemonMutex\d+$",
+        ]
+
+        for indicator in indicators:
+            if self.check_mutex(pattern=indicator, regex=True):
+                return True
+
+        return False


### PR DESCRIPTION
Reference: https://www.welivesecurity.com/2018/09/05/powerpool-malware-exploits-zero-day-vulnerability/

Tested hashes:
035f97af0def906fbd8f7f15fb8107a9e852a69160669e7c0781888180cd46d5
8c2e729bc086921062e214b7e4c9c4ddf324a0fa53b4ed106f1341cfe8274fe4
8c32d6f2408115476c5552a4e3e86a3cc5e7148cc0111a4b464509461f3c0d20
fb05c7b6087ebaf129036639e3cd9cd199ab450d69c2faac4a51064c1505334d