### PR TITLE
Added support for dumping MS-DOS executables

### DIFF
--- a/modules/processing/procdump.py
+++ b/modules/processing/procdump.py
@@ -36,16 +36,19 @@ class ProcDump(Processing):
             file_info["module_path"] = metastrings[3]
             file_info["process_name"] = file_info["process_path"].split("\\")[-1]
             file_info["pid"] = metastrings[1]
-            file_info["cape_type"] = "PE image"
             type_strings = file_info["type"].split()
-            if type_strings[0] == ("PE32+"):
-                file_info["cape_type"] += ": 64-bit "
-            elif type_strings[0] == ("PE32"):
-                file_info["cape_type"] += ": 32-bit "
-            if type_strings[2] == ("(DLL)"):
-                file_info["cape_type"] += "DLL"
+            if type_strings[0] == "MS-DOS":
+                file_info["cape_type"] = "DOS MZ image: executable"
             else:
-                file_info["cape_type"] += "executable"
+                file_info["cape_type"] = "PE image"
+                if type_strings[0] == ("PE32+"):
+                    file_info["cape_type"] += ": 64-bit "
+                elif type_strings[0] == ("PE32"):
+                    file_info["cape_type"] += ": 32-bit "
+                if type_strings[2] == ("(DLL)"):
+                    file_info["cape_type"] += "DLL"
+                else:
+                    file_info["cape_type"] += "executable"
             texttypes = [
                 "ASCII",
                 "Windows Registry text",


### PR DESCRIPTION
I'll add a MS-DOS executable to test for you later,
the problem was an IndexError at type_strings[2], since type_strings would be "MS-DOS executable"