### PR TITLE
Fix Regular Expression injection

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -673,7 +673,7 @@ def search_behavior(request, task_id):
 
         query = query.strip()
 
-        query = re.compile(query)
+        query = re.compile(re.escape(query))
 
         # Fetch anaylsis report
         if enabledconf["mongodb"]:


### PR DESCRIPTION
The fact of not sanitizing user input appended to a regular expression may lead to a `Regular Expression Denial of Service` by an attacker crafting a regular expression taking too much to load, or simply change the behaviour of the program.

Vulnerable code:

https://github.com/ctxis/CAPE/blob/0d830d3cdc241901a9ec1e2a6bfc59eb2f202551/web/analysis/views.py#L676

References:

[OWASP ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)